### PR TITLE
Fix call to DNSServiceBrowse() to not pass null domain.

### DIFF
--- a/jucey_bonjour/bonjour/jucey_BonjourService.cpp
+++ b/jucey_bonjour/bonjour/jucey_BonjourService.cpp
@@ -425,7 +425,7 @@ namespace jucey
                                                             0,
                                                             interfaceIndex,
                                                             type.toUTF8(),
-                                                            domain.isEmpty() ? nullptr : domain.toUTF8(),
+                                                            domain.toUTF8(),
                                                             &Pimpl::browseReply,
                                                             this))};
 


### PR DESCRIPTION
In `BonjourService::discoverAsync()` it passes `nullptr` as `domain` argument
if it's empty.

It should be correct, as `DNSServiceBrowse()` describes the arguments as:

```
DNSServiceErrorType DNSServiceBrowse
	(
	DNSServiceRef                       *sdRef,
	DNSServiceFlags                     flags,
	uint32_t                            interfaceIndex,
	const char                          *regtype,
	const char                          *domain,    /* may be NULL */
	DNSServiceBrowseReply               callback,
	void                                *context    /* may be NULL */
	)
```

However, it is actually not implemented as such(!).
Unlike `dnssd_clientstub.c`, `dnssd_clientshim.c` implements the function
to not accept null:

https://github.com/stbuehler/mDNSResponder/blob/56ab5b1/mDNSShared/dnssd_clientshim.c#L402

It is a bug in Apple mdnsresponder, not a bug in jucey_bonjour. But in order to 
workaround the issue it would be necessary to not dare to convert `""` to `null`
in this case.